### PR TITLE
Fix types in PhpDoc

### DIFF
--- a/library/AltrEgo/Adapter/AdapterInterface.php
+++ b/library/AltrEgo/Adapter/AdapterInterface.php
@@ -61,7 +61,7 @@ interface AdapterInterface
 
     /**
      * Check if a variable is set
-     * @param $name name of variable
+     * @param string $name name of variable
      * @return boolean
      */
     public function _isset($name);

--- a/library/AltrEgo/AltrEgo.php
+++ b/library/AltrEgo/AltrEgo.php
@@ -50,7 +50,7 @@ class AltrEgo
 
 	/**
 	 * Routine calls are sent to a PHP version specific adapter
-	 * @var unknown_type
+	 * @var object
 	 */
 	protected $adapter;
 
@@ -93,7 +93,7 @@ class AltrEgo
 
 	/**
 	 * Factory call to create an alter ego
-	 * @param unknown_type $obj
+	 * @param object $obj
 	 */
 	public static function create($obj)
 	{


### PR DESCRIPTION
Hello,

Thank you for the library - really helpful, especially in unit tests.

This pull request only fixes a couple of PhpDoc comments, because that "`@var unknown_type`" breaks static analysis of my code where it uses your library. It's my first PR on GitHub, please feel free to comment if I did something wrong.

Best regards,
Artem
